### PR TITLE
feat(docker): add multi-stage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-frontend
-backend
 bin
 node_modules
 project_assets


### PR DESCRIPTION
- Phases de builde et de run dans l'image docker (https://docs.docker.com/engine/userguide/eng-image/multistage-build/).
- On utilise l'image officiel java (openjdk) plutôt que d'installer à la main (https://hub.docker.com/_/openjdk/).
- On utilise Tini pour être sûr de ne pas avoir de processus zombie (https://github.com/krallin/tini).

PS : java 9 avec alpine n'est pas encore dispo il faut attendre un peu je pense.